### PR TITLE
RUMM-860 iOS generator linter fixes

### DIFF
--- a/generators/gen_ios.py
+++ b/generators/gen_ios.py
@@ -51,25 +51,36 @@ class IOSGenerator:
                 output.write(" */\n")
 
             output.write("@objc(" + definition['name'] + ")\n")
-            output.write("public protocol " + definition['name'] + " {\n\n")
+            output.write("public protocol " + definition['name'] + " {\n")
 
-            for method in definition['methods']:
-                if 'documentation' in method:
-                    output.write("    /**\n")
-                    output.write("       " + method['documentation'] + '\n')
-                    output.write("     */\n")
-
-                output.write("    func " + method['name'] + "(")
-
-                for i, param in enumerate(method['parameters']):
-                    if i > 0:
-                        output.write(", ")
-                    output.write(param['name'] + ": " + _get_ios_type_swift(param['type']))
-                output.write(") -> ")
-                output.write(_get_ios_type_swift(method['type']))
-                output.write("\n\n")
-
+            method_signatures = map(self._ios_method_signature, definition['methods'])
+            output.write("\n".join(method_signatures))
             output.write("}\n")
+
+    def _ios_method_signature(self, method):
+        output = ""
+        if 'documentation' in method:
+            output += "    /**\n"
+            output += "       " + method['documentation'] + '\n'
+            output += "     */\n"
+
+        output += "    func " + method['name'] + "("
+
+        for i, param in enumerate(method['parameters']):
+            if i > 0:
+                output += ", "
+
+            output += param['name'] + ": " + _get_ios_type_swift(param['type'])
+
+        output += ")"
+
+        method_type = _get_ios_type_swift(method['type'])
+        if method_type is not IOS_TYPES_SWIFT[TYPE_VOID]:
+            output += " -> "
+            output += _get_ios_type_swift(method_type)
+
+        output += "\n"
+        return output
 
     def _generate_ios_data(self, definition: dict):
         file_name = definition['name'] + ".swift"
@@ -96,7 +107,7 @@ class IOSGenerator:
             output.write(")\n")
             output.write("public class ")
             output.write(definition['name'])
-            output.write(": NSObject{\n")
+            output.write(": NSObject {\n")
             for i, prop in enumerate(definition['properties']):
                 if i > 0:
                     output.write("\n")

--- a/tests/gen_ios/test_combined/expected/Sources/Bridge/BridgeWithData.swift
+++ b/tests/gen_ios/test_combined/expected/Sources/Bridge/BridgeWithData.swift
@@ -11,15 +11,13 @@ import Foundation
  */
 @objc(BridgeWithData)
 public protocol BridgeWithData {
-
     /**
        Empty method, ComplexDataStructure param, returns void
      */
-    func setData(value: ComplexDataStructure) -> Void
+    func setData(value: ComplexDataStructure)
 
     /**
        Empty method, returns ComplexDataStructure
      */
     func getData() -> ComplexDataStructure
-
 }

--- a/tests/gen_ios/test_combined/expected/Sources/Bridge/ComplexDataStructure.swift
+++ b/tests/gen_ios/test_combined/expected/Sources/Bridge/ComplexDataStructure.swift
@@ -14,7 +14,7 @@ import Foundation
      - someMap: A mandatory map property
  */
 @objc(ComplexDataStructure)
-public class ComplexDataStructure: NSObject{
+public class ComplexDataStructure: NSObject {
     public var someLong: Int64 = 0
     public var someString: NSString? = nil
     public var someMap: NSDictionary = NSDictionary()

--- a/tests/gen_ios/test_interface/expected/Sources/Bridge/Getter.swift
+++ b/tests/gen_ios/test_interface/expected/Sources/Bridge/Getter.swift
@@ -11,11 +11,10 @@ import Foundation
  */
 @objc(Getter)
 public protocol Getter {
-
     /**
        Empty method, returns void
      */
-    func emptyMethod() -> Void
+    func emptyMethod()
 
     /**
        Empty method, returns boolean
@@ -46,5 +45,4 @@ public protocol Getter {
        Empty method, returns list
      */
     func getList() -> NSArray
-
 }

--- a/tests/gen_ios/test_interface/expected/Sources/Bridge/Setter.swift
+++ b/tests/gen_ios/test_interface/expected/Sources/Bridge/Setter.swift
@@ -11,35 +11,33 @@ import Foundation
  */
 @objc(Setter)
 public protocol Setter {
-
     /**
        Empty method, boolean param, returns void
      */
-    func setBoolean(value: Bool) -> Void
+    func setBoolean(value: Bool)
 
     /**
        Empty method, long param, returns void
      */
-    func setLong(value: Int64) -> Void
+    func setLong(value: Int64)
 
     /**
        Empty method, double param, returns void
      */
-    func setDouble(value: Double) -> Void
+    func setDouble(value: Double)
 
     /**
        Empty method, string param, returns void
      */
-    func setString(value: NSString) -> Void
+    func setString(value: NSString)
 
     /**
        Empty method, map param, returns void
      */
-    func setMap(value: NSDictionary) -> Void
+    func setMap(value: NSDictionary)
 
     /**
        Empty method, list param, returns void
      */
-    func setList(value: NSArray) -> Void
-
+    func setList(value: NSArray)
 }

--- a/tests/gen_ios/test_structure/expected/Sources/Bridge/DataStructure.swift
+++ b/tests/gen_ios/test_structure/expected/Sources/Bridge/DataStructure.swift
@@ -17,7 +17,7 @@ import Foundation
      - someMap: A mandatory map property
  */
 @objc(DataStructure)
-public class DataStructure: NSObject{
+public class DataStructure: NSObject {
     public var someBoolean: Bool = false
     public var someLong: Int64 = 0
     public var someDouble: Double = 0.0

--- a/tests/gen_ios/test_structure/expected/Sources/Bridge/DataStructureOptional.swift
+++ b/tests/gen_ios/test_structure/expected/Sources/Bridge/DataStructureOptional.swift
@@ -17,7 +17,7 @@ import Foundation
      - someMap: An optional map property
  */
 @objc(DataStructureOptional)
-public class DataStructureOptional: NSObject{
+public class DataStructureOptional: NSObject {
     public var someBoolean: Bool? = nil
     public var someLong: Int64? = nil
     public var someDouble: Double? = nil


### PR DESCRIPTION
#### Extra newlines at the top and bottom are removed

1. Before:
```swift
protocol Proto {

  // Documentation
  func fooBar()

}
```
2. After:
```swift
protocol Proto {
  // Documentation
  func fooBar()
}
```

#### Return `Void` is omitted

1. Before:
```swift
func fooBar() -> Void
```
2. After:
```swift
func fooBar()
```