### PR TITLE
RUMM-1162 Add setUser method to set the user information

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -12,6 +12,12 @@ The entry point to initialize Datadog's features.
 
     - `configuration`: The configuration to use.
 
+- `setUser(user: map)`
+
+    Set the user information.
+
+    - `user`: The user object (use builtin attributes: 'id', 'email', 'name', and/or any custom attribute).
+
 #### DdLogs
 
 The entry point to use Datadog's Logs feature.

--- a/mobile-bridge-api.json
+++ b/mobile-bridge-api.json
@@ -40,6 +40,18 @@
             "documentation": "The configuration to use."
           }
         ]
+      },
+      {
+        "name": "setUser",
+        "type": "void",
+        "documentation": "Set the user information.",
+        "parameters": [
+          {
+            "name": "user",
+            "type": "map",
+            "documentation": "The user object (use builtin attributes: 'id', 'email', 'name', and/or any custom attribute)."
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
### What does this PR do?

Add a `setUser` method to let bridge SDKs set the user information. 

### Additional Notes

The signature matches the one used in the `browser-sdk`. 
