### PR TITLE
RUMM-1040 add adddionalConfiguration

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -162,4 +162,5 @@ A configuration object to initialize Datadog's features.
 - `env` (string): The application’s environment, for example: prod, pre-prod, staging, etc.
 - `applicationId` (string): The RUM application ID.
 - `sampleRate` (double): The sample rate (between 0 and 100) of RUM sessions kept.
+- `additionalConfig` (map): Additional configuration parameters.
 

--- a/mobile-bridge-api.json
+++ b/mobile-bridge-api.json
@@ -27,6 +27,12 @@
         "type": "double",
         "documentation": "The sample rate (between 0 and 100) of RUM sessions kept.",
         "mandatory": false
+      },
+      {
+        "name": "additionalConfig",
+        "type": "map",
+        "documentation": "Additional configuration parameters.",
+        "mandatory": false
       }
     ]
   },


### PR DESCRIPTION
### What does this PR do?

Add an additionalConfiguration param at initialization to pass in additional configuration (duh). E.g. to set the framework tag.