### PR TITLE
RUMM-1175 Let bridge enable/disable native crash reports

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -161,6 +161,7 @@ A configuration object to initialize Datadog's features.
 - `clientToken` (string): A valid Datadog client token.
 - `env` (string): The application’s environment, for example: prod, pre-prod, staging, etc.
 - `applicationId` (string): The RUM application ID.
+- `nativeCrashReportEnabled` (boolean): Whether the SDK should track native (pure iOS or pure Android) crashes (default is false).
 - `sampleRate` (double): The sample rate (between 0 and 100) of RUM sessions kept.
 - `additionalConfig` (map): Additional configuration parameters.
 

--- a/mobile-bridge-api.json
+++ b/mobile-bridge-api.json
@@ -23,6 +23,12 @@
         "mandatory": false
       },
       {
+        "name": "nativeCrashReportEnabled",
+        "type": "boolean",
+        "documentation": "Whether the SDK should track native (pure iOS or pure Android) crashes (default is false).",
+        "mandatory": false
+      },
+      {
         "name": "sampleRate",
         "type": "double",
         "documentation": "The sample rate (between 0 and 100) of RUM sessions kept.",


### PR DESCRIPTION
### What does this PR do?

Let bridge SDK disable/enable native crash reports.

### Motivation

Among others, this is to
- not track anything we're not asked to
- help customer onboard when they are using competitor's native crash reporting.