### PR TITLE
RUMM-1304: Define tracking consent bridge interface

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -24,6 +24,12 @@ The entry point to initialize Datadog's features.
 
     - `user`: The user object (use builtin attributes: 'id', 'email', 'name', and/or any custom attribute).
 
+- `setTrackingConsent(trackingConsent: string)`
+
+    Set the tracking consent regarding the data collection.
+
+    - `trackingConsent`: Consent, which can take one of the following values: 'pending', 'granted', 'not_granted'.
+
 #### DdLogs
 
 The entry point to use Datadog's Logs feature.
@@ -164,5 +170,6 @@ A configuration object to initialize Datadog's features.
 - `nativeCrashReportEnabled` (boolean): Whether the SDK should track native (pure iOS or pure Android) crashes (default is false).
 - `sampleRate` (double): The sample rate (between 0 and 100) of RUM sessions kept.
 - `site` (string): The Datadog site of your organization (can be 'US', 'EU' or 'GOV', default is 'US').
+- `trackingConsent` (string): Consent, which can take one of the following values: 'pending', 'granted', 'not_granted'.
 - `additionalConfig` (map): Additional configuration parameters.
 

--- a/mobile-bridge-api.json
+++ b/mobile-bridge-api.json
@@ -41,6 +41,12 @@
         "mandatory": false
       },
       {
+        "name": "trackingConsent",
+        "type": "string",
+        "documentation": "Consent, which can take one of the following values: 'pending', 'granted', 'not_granted'.",
+        "mandatory": false
+      },
+      {
         "name": "additionalConfig",
         "type": "map",
         "documentation": "Additional configuration parameters.",
@@ -86,6 +92,18 @@
             "name": "user",
             "type": "map",
             "documentation": "The user object (use builtin attributes: 'id', 'email', 'name', and/or any custom attribute)."
+          }
+        ]
+      },
+      {
+        "name": "setTrackingConsent",
+        "type": "void",
+        "documentation": "Set the tracking consent regarding the data collection.",
+        "parameters": [
+          {
+            "name": "trackingConsent",
+            "type": "string",
+            "documentation": "Consent, which can take one of the following values: 'pending', 'granted', 'not_granted'."
           }
         ]
       }


### PR DESCRIPTION
### What does this PR do?

This change defines bridge interface for setting tracking consent either as a part of initial SDK configuration used during the initialization step (optional parameter), or as a dedicated method of SDK class.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

