### PR TITLE
RUMM-1417: Add a possibility to enable or disable tracer

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -178,4 +178,5 @@ A configuration object to initialize Datadog's features.
 - `site` (string): The Datadog site of your organization (can be 'US', 'EU' or 'GOV', default is 'US').
 - `trackingConsent` (string): Consent, which can take one of the following values: 'pending', 'granted', 'not_granted'.
 - `additionalConfig` (map): Additional configuration parameters.
+- `manualTracingEnabled` (boolean): Whether the SDK should enable tracer to be able to submit spans from the user (default is false).
 

--- a/mobile-bridge-api.json
+++ b/mobile-bridge-api.json
@@ -51,6 +51,12 @@
         "type": "map",
         "documentation": "Additional configuration parameters.",
         "mandatory": false
+      },
+      {
+        "name": "manualTracingEnabled",
+        "type": "boolean",
+        "documentation": "Whether the SDK should enable tracer to be able to submit spans from the user (default is false).",
+        "mandatory": false
       }
     ],
     "exposed": false


### PR DESCRIPTION
### What does this PR do?

This change brings a flag to enable/disable `Tracer` at the SDK configuration step. `Tracer` won't be enabled by default to because it is not a part of `Datadog#initialize` call and it is a responsibility of the client to enable it.

We will enable tracer will default config (subject for the improvement in future), by default it will be disabled (considering that it is needed for the expert users only).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

