### PR TITLE
Revert "RUMM-1417: Add a possibility to enable or disable tracer"

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -178,5 +178,4 @@ A configuration object to initialize Datadog's features.
 - `site` (string): The Datadog site of your organization (can be 'US', 'EU' or 'GOV', default is 'US').
 - `trackingConsent` (string): Consent, which can take one of the following values: 'pending', 'granted', 'not_granted'.
 - `additionalConfig` (map): Additional configuration parameters.
-- `manualTracingEnabled` (boolean): Whether the SDK should enable tracer to be able to submit spans from the user (default is false).
 

--- a/mobile-bridge-api.json
+++ b/mobile-bridge-api.json
@@ -51,12 +51,6 @@
         "type": "map",
         "documentation": "Additional configuration parameters.",
         "mandatory": false
-      },
-      {
-        "name": "manualTracingEnabled",
-        "type": "boolean",
-        "documentation": "Whether the SDK should enable tracer to be able to submit spans from the user (default is false).",
-        "mandatory": false
       }
     ],
     "exposed": false


### PR DESCRIPTION
This reverts commit 39be728730ca69f4ffd62192e1e577dea1fd0530.

### What does this PR do?

Revert #27, because we will go with isolated tracer for now.