### PR TITLE
RUMM-1505: Update CI image to Ubuntu 18.04

### DIFF
--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM registry.ddbuild.io/images/mirror/ubuntu:18.04
 LABEL maintainer="Team Mobile Rum <team-mobile-rum@datadoghq.com>"
 
 RUN set -x \


### PR DESCRIPTION
### What does this PR do?

This change updates Ubuntu version used in CI image from `16.04` to `18.04`.

The old tag is overwritten instead of publishing the new one. New Docker image is pushed and `cat /etc/lsb-release` for the `486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/dd-mobile-bridge:1` now gives the following:

```
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=18.04
DISTRIB_CODENAME=bionic
DISTRIB_DESCRIPTION="Ubuntu 18.04.5 LTS"
```