### PR TITLE
RUMM-1697: Add resource size argument to the stopResource method

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -138,13 +138,14 @@ The entry point to use Datadog's RUM feature.
     - `context`: Optional. The additional context to send.
     - `timestampMs`: Optional. The timestamp when the resource started (in milliseconds). If not provided, current timestamp will be used.
 
-- `stopResource(key: string, statusCode: long, kind: string, context: map, timestampMs: long)`
+- `stopResource(key: string, statusCode: long, kind: string, size: long, context: map, timestampMs: long)`
 
     Stop tracking a RUM Resource.
 
     - `key`: The resource unique key identifier.
     - `statusCode`: The resource status code.
     - `kind`: The resource's kind (xhr, document, image, css, font, …).
+    - `size`: Optional. The resource size in bytes.
     - `context`: Optional. The additional context to send.
     - `timestampMs`: Optional. The timestamp when the resource stopped (in milliseconds). If not provided, current timestamp will be used.
 

--- a/mobile-bridge-api.json
+++ b/mobile-bridge-api.json
@@ -497,6 +497,15 @@
             "documentation": "The resource's kind (xhr, document, image, css, font, …)."
           },
           {
+            "name": "size",
+            "type": "long",
+            "optional": true,
+            "defaultValue": {
+              "react-native": "-1"
+            },
+            "documentation": "The resource size in bytes."
+          },
+          {
             "name": "context",
             "type": "map",
             "optional": true,


### PR DESCRIPTION
### What does this PR do?

This changed adds resource size argument to the `stopResource` method.

Unfortunately, it will break public API a bit, because it is added as a mandatory argument in the middle of the arguments list (for example, all arguments in JS/TS are positional). But it is better to do it now. Adding it as a key of `context` makes it non-obvious for the end-user and brings inconsistency with native SDK API, adding it as optional parameter to the end of the list will force user to always specify `context` and `timestamp` arguments in the calls, which is also not a good change.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

