### PR TITLE
Update DataDog sites description, open dependant PRs in the draft state

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -176,7 +176,7 @@ A configuration object to initialize Datadog's features.
 - `applicationId` (string): The RUM application ID.
 - `nativeCrashReportEnabled` (boolean): Whether the SDK should track native (pure iOS or pure Android) crashes (default is false).
 - `sampleRate` (double): The sample rate (between 0 and 100) of RUM sessions kept.
-- `site` (string): The Datadog site of your organization (can be 'US', 'EU' or 'GOV', default is 'US').
+- `site` (string): The Datadog site of your organization (can be 'US1', 'US1_FED', 'US3', 'US5', or 'EU1', default is 'US1').
 - `trackingConsent` (string): Consent, which can take one of the following values: 'pending', 'granted', 'not_granted'.
 - `additionalConfig` (map): Additional configuration parameters.
 

--- a/mobile-bridge-api.json
+++ b/mobile-bridge-api.json
@@ -37,7 +37,7 @@
       {
         "name": "site",
         "type": "string",
-        "documentation": "The Datadog site of your organization (can be 'US', 'EU' or 'GOV', default is 'US').",
+        "documentation": "The Datadog site of your organization (can be 'US1', 'US1_FED', 'US3', 'US5', or 'EU1', default is 'US1').",
         "mandatory": false
       },
       {

--- a/update_dependants.py
+++ b/update_dependants.py
@@ -46,7 +46,7 @@ def github_create_pr(repository: str, branch_name: str, base_name: str, version:
     }
     data = '{"body": "This PR has been created automatically by the CI", ' \
            '"title": "Update to version ' + version + '", ' \
-                                                      '"base":"' + base_name + '", "head":"' + branch_name + '"}'
+           '"base":"' + base_name + '", "draft": true, "head":"' + branch_name + '"}'
 
     url = "https://api.github.com/repos/DataDog/" + repository + "/pulls"
     response = requests.post(url=url, headers=headers, data=data)


### PR DESCRIPTION
### What does this PR do?

This change brings the following:

* Updates DataDog sites description to include `US3`, `US5`.
* Dependant PRs will be created in the draft state, because they need additional work anyway, so that reviewers are not notified about uncomplete PRs.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

